### PR TITLE
Fixed issue with non contiguous device IDs not rendering

### DIFF
--- a/app.py
+++ b/app.py
@@ -41,6 +41,9 @@ def index():
         fileobj = StringIO.StringIO(content)
         data = RingData.load(fileobj)
         replica2part2dev_id = map(list, data._replica2part2dev_id)
+        #remove null devices
+        new_devs = [ dev for dev in data.devs if dev is not None ]
+        data.devs = new_devs
 
     return render_template('index.htm', 
         data=data,

--- a/templates/index.htm
+++ b/templates/index.htm
@@ -76,12 +76,21 @@
         }
 
         var colors = [];
+        // get list of device IDs
+        var devids = [];
+        for (var devid in views.devices) {
+            if (views.devices.hasOwnProperty(devid)) {
+                devids.push(devid);
+            }
+        }
         var delta = 360.0 / devs.length;
         for (var i = 0; i < devs.length; ++i) {
-            var color = d3.hsl(delta * i, 0.9, 0.5);
-            colors.push(color);
-            views.devices[i].label_color = color;
-            views.devices[i].update();
+            if (views.devices[devids[i]] !== undefined) {
+                var color = d3.hsl(delta * i, 0.9, 0.5);
+                colors.push(color);
+                views.devices[devids[i]].label_color = color;
+                views.devices[devids[i]].update();
+            }
         }
 
         var radius_delta = 80 / replica2part2dev_id.length;


### PR DESCRIPTION
Removed "null" devices from ring parse
Fixed device color assignment looping

If you're inspecting a ring from a "real" swift cluster, some times devices have been removed and the device ID numbering is no longer contiguous.  This patch will allow non-contiguous devices in a ring to render properly